### PR TITLE
using widgets.dart rather than material.dart

### DIFF
--- a/lib/provider_widget.dart
+++ b/lib/provider_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
 /// A widget that provides a value passed through a provider as a parameter of the build function.

--- a/lib/viewmodel_provider.dart
+++ b/lib/viewmodel_provider.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
 enum _ViewModelProviderType { WithoutConsumer, WithConsumer }


### PR DESCRIPTION
Since there seems to be no absolute requirement to use material.dart, it would be better to use the lower level widgets.dart. That way there would not be potential conflicts for users who want to use cupertino.dart.