### PR TITLE
added widget test for package and example

### DIFF
--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,30 +1,13 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
+import 'package:example/main.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:example/main.dart';
-
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('Smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the names and surnames are displayed properly
+    expect(find.text('Dane'), findsWidgets);
+    expect(find.text('Mackier'), findsOneWidget);
   });
 }

--- a/test/provider_architecture_test.dart
+++ b/test/provider_architecture_test.dart
@@ -1,3 +1,92 @@
-void main() {
+import 'package:flutter/material.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
+import '../lib/provider_architecture.dart';
+
+void main() {
+  testWidgets('ProviderWidget', (WidgetTester tester) async {
+    // Build our app and trigger a frame
+    await tester.pumpWidget(ChangeNotifierProvider(
+      create: (context) => MyProvider(0),
+      child: MyApp(),
+    ));
+
+    expect(find.text('0'), findsOneWidget);
+  });
+
+  testWidgets("ViewModelProvider with Consumer", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ViewModelProvider<MyProvider>.withConsumer(
+        viewModel: MyProvider(0),
+        builder: (context, model, child) => MaterialApp(
+            home: Scaffold(
+          body: Text(
+            model.count.toString(),
+            textDirection: TextDirection.ltr,
+          ),
+          floatingActionButton: FloatingActionButton(
+            key: Key("fabButton"),
+            onPressed: () => model.increment(),
+            child: Icon(Icons.add),
+          ),
+        )),
+      ),
+    );
+    expect(find.text('0'), findsOneWidget);
+    await tester.tap(find.byType(Icon));
+    await tester.pump();
+    // We should be able to find Text with value 1
+    expect(find.text('1'), findsOneWidget);
+  });
+
+  testWidgets("ViewModelProvider without Consumer",
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ViewModelProvider<MyProvider>.withoutConsumer(
+        viewModel: MyProvider(0),
+        builder: (context, model, child) => MaterialApp(
+            home: Scaffold(
+          body: Text(
+            model.count.toString(),
+            textDirection: TextDirection.ltr,
+          ),
+          floatingActionButton: FloatingActionButton(
+            key: Key("fabButton"),
+            onPressed: () => model.increment(),
+            child: Icon(Icons.add),
+          ),
+        )),
+      ),
+    );
+    expect(find.text('0'), findsOneWidget);
+    await tester.tap(find.byType(Icon));
+    await tester.pump();
+    // We should not be able to find Text with value 1
+    expect(find.text('1'), findsNothing);
+  });
+}
+
+class MyApp extends ProviderWidget<MyProvider> {
+  MyApp() : super(listen: true);
+
+  @override
+  Widget build(BuildContext context, model) {
+    return Text(
+      model.count.toString(),
+      textDirection: TextDirection.ltr,
+    );
+  }
+}
+
+class MyProvider extends ChangeNotifier {
+  int count;
+
+  MyProvider(this.count);
+
+  increment() {
+    count++;
+    notifyListeners();
+  }
 }


### PR DESCRIPTION
Added widget test for package and example. For the package, I have added widget test for `ProviderWidget`, `ViewModelProvider.withConusmer` as well as `ViewModelProvider.withoutConsumer`,

#12 While opening the issue, I was facing difficulty to write the test cases and thought it was related to this package. After doing some research, I found out it was due to Provider Package.

The test cases will be helpful to you to check if package is working properly or not after every update.